### PR TITLE
v0.8.0 — CMS parity, routing, taxonomy, and unified classification surface (Stages 0–7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Sugartown monorepo are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+> **Version note:** Entries from `[0.0.0]` onwards use SemVer and track the monorepo.
+> Entries marked `[Pre-monorepo]` are historical records reconstructed from preserved
+> git history in `sugartown-frontend`, `sugartown-sanity`, `repos/sugartown-pink`, and
+> `repos/sugartown-cms`. Live site remains WordPress throughout all pre-monorepo eras.
+
 ---
 
 ## [0.8.0] — 2026-02-19
@@ -97,7 +102,153 @@ tags[]       → tag refs (neutral chip)
 
 ---
 
-## [0.0.0] — baseline
+## [0.0.0] — 2026-01-31 — Monorepo baseline
 
-Initial monorepo scaffold. Frontend and Studio imported as subtrees.
+Initial monorepo scaffold: `sugartown-frontend` and `sugartown-sanity` imported as git
+subtrees into a pnpm workspaces + Turborepo root. History from both repos preserved intact.
 Tag: `v1.0.0-baseline`
+
+Repos merged:
+- `sugartown-frontend` (Jan 19–31) → `apps/web`
+- `sugartown-sanity` (Jan 18–31) → `apps/studio`
+
+> See `[Pre-monorepo / v1]` below for the full history of what was imported.
+
+---
+
+<!-- ============================================================ -->
+<!-- PRE-MONOREPO HISTORY                                         -->
+<!-- Reconstructed from preserved git repos. Not SemVer releases. -->
+<!-- Live site = WordPress throughout both eras below.            -->
+<!-- ============================================================ -->
+
+## [Pre-monorepo / v1] — 2026-01-18 to 2026-01-31 — Dual-Repo React + Sanity MVP
+
+**Repos:** `sugartown-frontend` · `sugartown-sanity`
+**Stack:** React 19 + Vite 7 · Sanity Studio v3 · separate git repos
+**Status:** Dev only — never deployed to production. WP live site unchanged.
+
+This era established the React + Sanity stack and the foundational content model.
+Both repos were created Jan 18–19, developed in parallel through Jan 31, then
+merged into the monorepo via git subtree on the same day.
+
+### sugartown-frontend
+
+#### Added
+- Initial React + Vite app with Sanity client integration (`ae05d2c` 2026-01-19)
+- Design System setup: media split, `SanityMedia` component (`f20eb6b` 2026-01-19)
+- Design tokens extracted from legacy CSS; components migrated to token architecture (`8e62c3c`, `a5213dc` 2026-01-24)
+- Duotone image effect utility (`6649f74` 2026-01-24)
+- Complete Sanity CMS schema architecture — Phase 1: `node`, `post`, `page`, `caseStudy`, taxonomy (`db6d192` 2026-01-24)
+- `NodesExample` component to display Knowledge Graph Nodes (`1f46649` 2026-01-25)
+- `siteSettings` integration: preheader and CTA button wired to frontend (`9f7af5c` 2026-01-25)
+- Homepage migrated to new Sanity schema (`2c48b58` 2026-01-25)
+- New Sanity content model for pages and site settings (`3447b7f` 2026-01-31)
+
+#### Changed
+- DS color: seafoam → green (`627eae3` 2026-01-19)
+- Hero: load button array (`04f5088` 2026-01-19)
+- Various layout and background fixes (2026-01-20)
+- `siteSettings` homepage schema with deprecations merged from branch `reverent-herschel` (`5d39793` 2026-01-25)
+
+### sugartown-sanity
+
+#### Added
+- Sanity Studio bootstrapped (`1c62923` 2026-01-18)
+- Initial Studio with atomic design schemas (`7f3f07a` 2026-01-19)
+- `preheader` and `ctaButtonDoc` schemas; `siteSettings` updated (`6542514` 2026-01-25)
+- `homepage` schema; legacy schemas deprecated (`b429e00` 2026-01-25)
+- `heroSection` updated to use `ctaButtonDoc` references (`f897d9f` 2026-01-25)
+- Legacy schemas deprecated; `editorialCard` object introduced (`3ff91b0` 2026-01-31)
+- Legacy MVP docs added; V1 CMS strategy PRD published (`0cfae4e`, `13454c1` 2026-01-31)
+- Architecture and schema reference docs consolidated via PRs #1–4 (`2026-01-31`)
+- `siteSettings` schema updated (`f3bba7a` 2026-01-31)
+
+#### Schema registry at merge (from `schemas/index.ts`):
+- **Objects (new):** `link`, `richImage`, `ctaButton`, `editorialCard`
+- **Objects (legacy):** `logo`, `media`, `navigationItem`, `socialLink`
+- **Sections:** `heroSection`, `textSection`, `imageGallery`, `ctaSection`
+- **Documents — taxonomy:** `category`, `tag`, `project`
+- **Documents — content:** `node`, `post`, `page`, `caseStudy`
+- **Documents — infrastructure:** `navigation`, `siteSettings`, `preheader`, `ctaButtonDoc`, `homepage`
+- **Documents — deprecated:** `header`, `footer`, `hero`, `contentBlock`
+
+#### GROQ queries at merge (from `sugartown-frontend/src/lib/queries.js`):
+- `siteSettingsQuery`, `homepageQuery`, `allNodesQuery`, `nodeBySlugQuery`
+- `allPostsQuery`, `postBySlugQuery`, `pageBySlugQuery`, `allCaseStudiesQuery`
+- `allCategoriesQuery`, `allTagsQuery`, `allProjectsQuery`
+- Legacy deprecated: `headerQuery`, `footerQuery`, `heroesQuery`, `contentBlocksQuery`
+
+---
+
+## [Pre-monorepo / v0] — 2025-11-27 to 2026-01-17 — WordPress + Python Pipeline
+
+**Repos:** `repos/sugartown-pink` (WP Block Theme) · `repos/sugartown-cms` (Python pipeline)
+**Stack:** WordPress Block Theme (PHP) · Python content pipeline (`publish_gem.py`) · no frontend framework
+**Status:** Production — live site throughout this era and all subsequent eras.
+
+The original platform. A custom WordPress Block Theme delivering the public site,
+with a Python-based content pipeline (`publish_gem.py`) for publishing gems to WP via API.
+Six named releases shipped to production during this era.
+
+### repos/sugartown-pink (WordPress Block Theme)
+
+#### Release history (all production)
+
+**2026-01-11 — Design System Alignment + Token Updates**
+- Upgraded Sugartown Pink to `#FF247D`; semantic tokens for single posts/pages
+- Fixed chip sizing, code block background CSS variable, content width constraints
+- Standardized footer pattern across archive and single templates
+- Accessibility and layout fixes for footer heading hierarchy
+
+**2026-01-03 — Responsive Tables Stabilization**
+- Fixed mobile table card layout: overflow, box-sizing, width constraints
+- Canonical design tokens confirmed loading correctly post-cache invalidation
+- Added `st-table`, `st-table--wide`; deprecated `st-table--review`
+- Added `st-filter`; deprecated `kg-filter`
+
+**2026-01-01 — Design System Alignment & Accessibility Audit**
+- Canonicalized `st-chip` as single interactive primitive across archive filters, hero nav, and metadata tags
+- Removed competing chip variant classes; normalized card border colors and grid spacing
+- Refactored CSS architecture: element styles moved to global base rules
+- Accessibility audit: 16 documented issues with priority levels
+- Created `CSS_FILE_ORGANIZATION_RULES.md`; standardized `ds-` → `st-` namespace
+
+**2025-12-29 — AI Governance + Design System Foundations**
+- Three-tier design token system: brand colors, spacing, typography
+- `st-*` namespace standardized across tokens and docs
+- AI Ethics & Operations policy published; design system ruleset and prompt templates published
+
+**2025-12-27 — Taxonomy v4 + Interactive Filter System**
+- `st-chip` interactive primitives for archive filters; floating multi-column dropdowns
+- Taxonomy v4 complete: WordPress categories as single source of truth; `gem_category` meta eliminated
+- Publisher v4.1: dynamic category ID lookup; auto-creates missing categories
+- Archive result counter reflects actual filtered results; pagination accuracy fixed
+
+**2025-12-24 — Knowledge Graph Landing + Template Integration**
+- `/knowledge-graph/` established as intentional section landing with narrative context
+- WP Block Theme template parts (`do_blocks()`) integrated in PHP templates
+- Content model rule established: narrative content as Gems; archive templates render structure only
+
+**2025-12-21 — Canonical st-card Adoption**
+- `st-card` replaces archive-specific gem cards; dark variant (`st-card--dark`) for system/infra gems
+
+**2025-12-19 — st-card Migration**
+- `pink-card` → `st-card`; canonical gradient recipe, unified tag/term styling
+
+**2025-12-17 — Design System v3.3**
+- Grid layout decoupled; overlap fixes; automation hook
+
+**2025-12-03–07 — Initial commits**
+- `Initial commit: Sugartown Pink Theme` (`7671c1c` 2025-12-03)
+- Stink Pink color iteration; post type updates (`5b4042c` 2025-12-07)
+
+### repos/sugartown-cms (Python pipeline)
+
+#### Added
+- Initial commit: pipeline scripts, README (`e8c40b7` 2025-11-27)
+- Resume ingestion workflow (`b883867` 2025-11-30)
+- Publishing Architecture Gem; upsert logic; Resume workflow gems (`2544791`, `274aed1` 2025-11-27–12-03)
+- `publish_gem.py` v3.7: draft-aware, fuzzy match, taxonomy-aware (`4012fd0` 2025-12-05)
+- Finalized README with v3.7 architecture (`69c6edd` 2025-12-05)
+- Synced with WP theme release history through Jan 2026

--- a/docs/drafts/gem-three-white-screens.md
+++ b/docs/drafts/gem-three-white-screens.md
@@ -1,0 +1,133 @@
+# We Fixed the Same White Screen Three Times (And Then Built a Prompt to Prevent It)
+
+*A brief meditation on AI-assisted development, branch hygiene, and the PM who kept asking the right questions*
+
+---
+
+There's a particular kind of embarrassment that comes from realising you've solved the same problem three times in ten days. It deepens considerably when you're the one who told the AI what was wrong every single time.
+
+This is that story.
+
+---
+
+## The Setup
+
+In late January 2026, Sugartown — a personal site and knowledge project — migrated from a WordPress/Python pipeline into a proper React + Sanity monorepo. Two legacy repos were subtree-imported into a single pnpm workspace. The history was preserved. The architecture was modern. The vibes were immaculate.
+
+And then the header and footer kept disappearing.
+
+---
+
+## Three Fixes, Ten Days, One Bug
+
+The root cause was mundane: during the migration, `Header.jsx` and `Footer.jsx` were half-migrated to a new `siteSettings` query pattern but still referenced the old variable names (`header`, `footer`) from the legacy queries. React threw a `ReferenceError`. The render tree died. White screen.
+
+Simple. Obvious. In retrospect.
+
+Here is how it got fixed:
+
+**February 7 — Fix #1** (`429390d`, branch: `objective-newton`)
+Minimal patch. Renamed the state variables. Fixed the wrong import. The commit message was clear, the fix was correct, the branch was never merged to `main`. It sat on a remote branch with an auto-generated name, quietly waiting to be discovered.
+
+**February 8 — Fix #2** (`9ba8d22`, branch: `upbeat-galileo`)
+New session, no memory of Fix #1. The white screen was encountered again. This time the response was more ambitious: threw out both components entirely, rewrote them as props-receiving components fed from a single top-level `siteSettings` fetch in `App.jsx`. Better architecture. Made it to `main`. Fix #1 was now unreachable and irrelevant, stranded on a remote branch no one was watching.
+
+**February 17 — Fix #3** (`e9fcdfc`, branch: `integration/parity-check`)
+Ten days later, during a major parity migration across eight sequential development stages. The white screen appeared in a new context. Fixed again — variable rename, query correction, import cleanup. Correct. Thorough. Completely unaware that `main` had already solved this with a superior architecture ten days prior.
+
+Three sessions. Three fixes. One bug. Zero cross-session awareness.
+
+---
+
+## Why This Keeps Happening
+
+Claude Code is, genuinely, astonishingly capable. It can read a codebase, trace a bug through component trees and query layers, write correct fixes, maintain architectural consistency across a complex multi-stage migration, and produce release documentation that a senior engineer would be proud of.
+
+What it cannot do is remember that it fixed this last Tuesday.
+
+Each session starts fresh. There is no ambient awareness of "oh, I saw something like this before." There is no internal alarm that says "wait — three branches touched this file in the last ten days, let me check whether this is already solved somewhere." The context window is wide but it is also bounded and it begins at zero every morning.
+
+This is not a criticism. It is a constraint. An important one.
+
+The irony is that the information needed to catch this was always present — in the git log, in the branch names, in the commit messages. The fix on `objective-newton` even had a clear commit message: *"fix undefined variable crashes in Header and Footer."* It just wasn't being looked at.
+
+---
+
+## The PM Who Kept Noticing
+
+Here is the part that deserves a dedicated section.
+
+Throughout this process, the human — a self-described lay person, a Product Manager who "doesn't really do code" — kept being the one to surface the pattern.
+
+*"Isn't this the same white screen issue from before?"*
+*"Didn't we fix the header already?"*
+*"This feels familiar."*
+
+This is not a small thing. The PM was functioning as the cross-session memory that the AI lacked. Not by reading commit hashes, but by holding the shape of the problem in their head over time. Pattern recognition across context boundaries. The thing that doesn't reset between sessions.
+
+The PM kept handing the AI the thread it had dropped. The AI kept being surprised to find it.
+
+This dynamic — lay person as the connective tissue between AI sessions — is worth naming explicitly, because it is almost certainly more common than anyone admits.
+
+---
+
+## What We Did About It
+
+The response to discovering Fix #3 was to build a morning housekeeping prompt: a structured git audit that runs at the start of every session and produces a plain-English briefing before any new work begins.
+
+It checks:
+- What branch you're on and whether it's stale
+- What files are uncommitted
+- What branches exist, which ones have unmerged work, and which ones are abandoned orphans
+- Whether any remote-only branches are hiding relevant history
+- What stashes have been forgotten
+
+It delivers a recommendation list in plain English, confirms each action before executing it, and refuses to merge, push, or delete anything without an explicit "yes."
+
+It is, in essence, a prompt that compensates for the absence of cross-session memory by making the first act of each session an honest audit of what the last session left behind.
+
+---
+
+## What This Still Doesn't Solve
+
+The housekeeping prompt is useful. It would have caught `objective-newton` on day two. It would have surfaced the unmerged fix before the second session encountered the same white screen.
+
+But it only works if it's run. And it only works if the output is read. And it only works if the human reviewing the briefing has enough context to recognise that "three branches touched Footer.jsx this week" is a signal worth investigating.
+
+Which brings us back to the PM noticing the pattern.
+
+The honest version of this story is:
+- AI is very good at executing within a session
+- AI has no memory between sessions by default
+- Documentation and git hygiene are the prosthetic memory
+- The human is the archivist
+
+---
+
+## Recommendations (Succinct, As Promised)
+
+**Run the morning housekeeping prompt.** Every session. Not when you remember to.
+
+**Merge or close branches within 48 hours.** An unmerged branch is a question mark that compounds. `objective-newton` would have been harmless if it had been merged or closed the day it was created.
+
+**Name your branches.** Auto-generated names (`distracted-hoover`, `upbeat-galileo`, `objective-newton`) are charming but they carry zero semantic information. A branch named `fix/header-footer-white-screen` gets noticed. A branch named `objective-newton` gets forgotten.
+
+**One canonical fix, one place.** When a bug is fixed, the fix should land on `main` before the next session starts. A fix that doesn't reach `main` doesn't exist as far as the next session is concerned.
+
+**Tell the AI what you remember.** If something feels familiar, say so at the start of the session. "I feel like we fixed something like this before" is a valid and useful input. The AI will go look. This is not cheating. This is correct use of the tool.
+
+**Write it down.** The `MEMORY.md` file in this project exists for exactly this reason — persistent facts that survive context resets. Bug patterns, fixed issues, gotchas encountered — these belong there. Not because the AI will remember, but because the file will.
+
+---
+
+## Coda
+
+We built a governance prompt to fix a governance problem that was itself caused by not having governance. This is either very on-brand for software development, or a perfect illustration of why process exists.
+
+The header is rendering correctly now.
+
+All three times.
+
+---
+
+*Part of the Sugartown knowledge graph — tools, workflows, and the occasional humbling lesson from the intersection of AI and product development.*

--- a/docs/morning-housekeeping-prompt.md
+++ b/docs/morning-housekeeping-prompt.md
@@ -1,0 +1,185 @@
+# PROMPT — Sugartown Morning Housekeeping
+**Version:** v1 (2026-02-20)
+**Run with:** Claude Code (project context required)
+**When to use:** First thing in the morning, before starting new work
+
+---
+
+## What this prompt does
+
+Runs a complete git health check on the Sugartown monorepo, then delivers a plain-English briefing: what state everything is in, what's unfinished, what needs action before starting new work, and what the recommended first moves are.
+
+It reads. It does not commit, merge, delete, or push anything without explicit confirmation at each step.
+
+---
+
+## The Prompt (copy and paste into Claude Code)
+
+---
+
+Good morning. Please run the Sugartown morning housekeeping check. Here is what I need you to do:
+
+### PHASE 1 — READ EVERYTHING (no changes yet)
+
+Run the following and collect all output before doing anything else:
+
+```bash
+git status
+git branch -a
+git log --oneline -10
+git stash list
+git diff --stat HEAD
+```
+
+Then for every local branch that is NOT `main`, run:
+```bash
+git log main..<branch> --oneline
+git log <branch>..main --oneline
+```
+
+Then check remote-only branches:
+```bash
+git fetch --dry-run
+```
+
+Do not take any action yet. Collect everything first.
+
+---
+
+### PHASE 2 — BUILD THE BRIEFING
+
+Write a plain-English morning briefing using exactly this structure. Use plain language throughout — assume I am not reading git output directly.
+
+---
+
+#### 🗓 Morning Briefing — [today's date]
+
+---
+
+#### 📍 Where you are right now
+
+- **Active branch:** what branch I'm on
+- **Sync status:** is this branch up to date with its remote? Behind? Ahead?
+- **Uncommitted changes:** list any modified or untracked files by name, one line each, with a plain description of what kind of file it is (e.g. "CHANGELOG.md — the project changelog, modified but not saved to git")
+
+---
+
+#### 🌿 Branch Map
+
+For each branch (local and remote), one line:
+- Branch name
+- Whether it has been merged into `main` or not
+- How many commits ahead of `main` it is (if any)
+- One-sentence plain description of what the branch appears to be for, based on its name and commit messages
+- Status tag: one of `✅ merged` / `⚠️ unmerged work` / `🔍 remote only` / `🗑 can probably be deleted`
+
+---
+
+#### ⚠️ Unfinished Business
+
+List anything that needs attention before starting new work. Be specific. Use plain language.
+
+Examples of things to flag:
+- Files modified but not committed
+- Untracked files that look like they belong in the repo (docs, scripts, config)
+- Branches with commits that haven't reached `main`
+- A branch I'm on that is behind `main` (I might be working on stale code)
+- Stashed changes I may have forgotten about
+- Remote branches with no local counterpart that have unmerged work
+
+Do not flag things that are fine. Only flag things that need a decision or action.
+
+If nothing needs attention, say so clearly.
+
+---
+
+#### ✅ Recommended Actions (in order)
+
+List the specific actions recommended before starting new work today. Number them. For each:
+
+1. **What to do** — one plain sentence
+2. **Why** — one plain sentence
+3. **The exact command or instruction** — ready to copy/paste or confirm
+
+Use this priority order:
+1. Commit or discard any uncommitted changes first
+2. Merge or close any branches that are ready
+3. Get onto the right branch for today's work
+4. Pull any remote updates
+
+If an action requires a judgment call (e.g. "should I delete this branch?"), ask me before acting — don't decide unilaterally.
+
+---
+
+#### 🔮 What I think today's starting point should be
+
+Based on the branch map and the MEMORY.md context you have about this project:
+- What branch should I be on when I start new work?
+- Is there anything obviously next in the project's progression that I should pick up?
+- Are there any blockers that would prevent starting new work cleanly?
+
+Keep this section short — 3–5 sentences max. Do not invent work. Only suggest what is visible from the git state and project memory.
+
+---
+
+### PHASE 3 — EXECUTE (with confirmation)
+
+After delivering the briefing, ask me:
+
+> "Ready to execute the recommended actions? I'll walk through them one at a time and confirm each with you before running anything."
+
+Then, when I say yes:
+- Do **one action at a time**
+- Show me the exact command before running it
+- Tell me what it will do in plain English
+- Wait for me to confirm ("yes", "go ahead", "skip", or "stop")
+- After each action, briefly confirm what happened
+- Do not batch actions together without asking
+
+**Hard rules for execution:**
+- Never `git push --force` under any circumstances
+- Never `git reset --hard` without explicit confirmation and a clear warning that it is destructive
+- Never delete a branch (local or remote) without showing me its last commit and asking explicitly
+- Never merge into `main` without saying "this will merge X into main — are you sure?"
+- Stash operations: always name the stash before creating it
+- If anything looks ambiguous or risky, stop and ask
+
+---
+
+### PHASE 4 — CLOSING CONFIRMATION
+
+After all actions are complete (or skipped), output a short closing status:
+
+```
+Morning housekeeping complete.
+
+Branch: [current branch]
+Uncommitted changes: [none / list]
+Unmerged branches: [none / list]
+Actions taken: [list or "none"]
+Actions skipped: [list or "none"]
+
+Ready to work. ✓
+```
+
+---
+
+## Reference: Sugartown Branch Conventions
+
+For context when interpreting branch names and states:
+
+- `main` — stable, releasable. All completed work should land here.
+- `integration/*` — staging branches for multi-stage feature work before merging to main
+- `feat/*` / `fix/*` / `chore/*` / `docs/*` — conventional commit-style feature branches
+- Auto-named branches (e.g. `distracted-hoover`, `upbeat-galileo`) — created by tools or AI agents; treat as temporary unless they have meaningful unmerged commits
+- `migrate/*` — one-time migration branches; should be fully merged and deletable
+- Remote-only branches with no local copy — check if they have unmerged work before ignoring
+
+## Reference: Known Active Surfaces
+
+- `apps/web` — React + Vite frontend
+- `apps/studio` — Sanity Studio CMS
+- `apps/storybook` — component library (not yet active)
+- `packages/design-system` — shared design tokens and components
+- `CHANGELOG.md` and `RELEASE_NOTES.md` — release documentation at repo root
+- `docs/` — internal project documentation (prompt files, strategy docs)

--- a/docs/release-assistant-prompt.md
+++ b/docs/release-assistant-prompt.md
@@ -1,0 +1,325 @@
+# PROMPT — Sugartown Release Assistant
+**Version:** v2 (2026-02-20)
+**Supersedes:** v1 (original WP/Python pipeline era prompt, pasted into Claude Code conversation)
+
+> **v1 → v2 changes:**
+> - Version format corrected from `vYYYY.MM.DD` to SemVer `[X.Y.Z]` (Keep a Changelog convention, matching actual CHANGELOG.md)
+> - `RELEASE_STATE.json` retired — see note in Step 3C
+> - Keep a Changelog sub-sections (`Added`, `Changed`, `Fixed`, `Removed`) now required within each surface block
+> - Empty surfaces explicitly forbidden in CHANGELOG output
+> - Supplementary reference blocks (route tables, schema snapshots) explicitly permitted as additive-only
+> - "Not in this release" section added to Release Notes format — required when partial implementations exist
+> - "Validator state at release" section added to Release Notes format — required when validation scripts were run
+> - Bug fix narration explicitly permitted in Release Notes (symptoms + resolution prose)
+> - Commit message format updated to conventional commits (`docs:` prefix)
+> - Version increment guidance (MAJOR/MINOR/PATCH) added
+
+---
+
+**Canonical hierarchy:**
+Reality → Changelog → Release Notes
+
+**Invariants:**
+- Changelog is the canonical ledger.
+- Release Notes are derived from the Changelog.
+- Nothing flows backward.
+- Nothing is inferred.
+- Nothing is invented.
+
+**Monorepo surfaces:**
+- `apps/web`
+- `apps/studio`
+- `apps/storybook`
+- `packages/design-system`
+- `packages/*`
+
+---
+
+## STEP 0 — COLLECT SIGNALS
+
+Use Claude Code to gather:
+
+```bash
+git diff --name-status <lastReleaseRef>..HEAD
+git log --oneline <lastReleaseRef>..HEAD
+```
+
+Group changed files by surface:
+- `apps/web`
+- `apps/studio`
+- `apps/storybook`
+- `packages/design-system`
+- other packages
+
+Output:
+- Raw factual bullet list per surface
+- No interpretation
+- No marketing language
+- No inferred intent
+
+---
+
+## STEP 1 — SOURCE OF TRUTH (Messy Reality)
+
+AI generates:
+
+```
+apps/web:
+• ...
+apps/studio:
+• ...
+packages/design-system:
+• ...
+apps/storybook:
+• ...
+```
+
+Rules:
+- Outcome-only bullets.
+- If a change cannot be supported by file diff or explicit human confirmation, exclude it.
+- Refactors allowed.
+- Internal migrations allowed.
+- Non-goals excluded.
+- Bug fixes included with exact symptoms where known.
+
+Human verifies and edits.
+Approved artifact becomes: **🧾 Source of Truth — What Was Done**
+
+---
+
+## STEP 2 — NORMALIZE (Mechanical Reduction)
+
+AI reduces Step 1 into:
+- Deduplicated bullets
+- Flat structure
+- Outcome-only
+- No interpretation
+- No narrative framing
+
+Human approves.
+This artifact becomes the canonical change input.
+
+---
+
+## STEP 3 — CHANGELOG GENERATION
+
+### Artifact Hierarchy Rule (LOCKED)
+
+1. Generate CHANGELOG entry first.
+2. Generate Release Notes ONLY from the CHANGELOG entry.
+3. Release Notes may summarize or group.
+4. Release Notes may NOT introduce new changes.
+5. Release Notes may NOT imply roadmap intent.
+6. Release Notes may NOT reinterpret refactors as features.
+
+If violated → FAIL and output a rule violation report.
+
+---
+
+### STEP 3A — Generate CHANGELOG.md Entry (Canonical Ledger)
+
+**Version format:** `[MAJOR.MINOR.PATCH]` using SemVer with date annotation.
+Do not use date-only versions (`vYYYY.MM.DD`).
+
+**Format:**
+
+```markdown
+## [X.Y.Z] — YYYY-MM-DD
+
+Brief descriptor. Branch: `feature-branch` → `main` (if a merge release).
+
+### apps/web
+
+#### Added
+- ...
+
+#### Changed
+- ...
+
+#### Fixed
+- ...
+
+### apps/studio
+
+#### Added
+- ...
+
+#### Changed
+- ...
+
+#### Fixed
+- ...
+
+### packages/design-system
+
+#### Added
+- ...
+
+### apps/storybook
+
+#### Added
+- ...
+
+### Sanity production data
+
+- ...
+
+### Other
+
+- ...
+```
+
+**Rules:**
+- Use Keep a Changelog section headers (`Added`, `Changed`, `Fixed`, `Removed`) within each surface.
+- Omit surfaces with no changes — do not include empty `### apps/storybook` sections.
+- Must include every normalized change from Step 2.
+- Must include refactors.
+- Must include migrations.
+- Must include bug fixes with the specific behavior that was broken and what was changed.
+- Must label breaking changes explicitly under `#### Breaking` or with a `**Breaking:**` prefix.
+- No marketing tone.
+- No summarization beyond grouping by surface and change type.
+- Supplementary blocks (canonical route tables, taxonomy surface tables, schema registry snapshots) are allowed after the bullet lists if they aid legibility — they are additive, not substitutes for bullets.
+
+This is the permanent historical record.
+
+---
+
+### STEP 3B — Generate Release Notes (Derived Narrative)
+
+**Input:** The generated CHANGELOG entry only.
+
+**Format:**
+
+```markdown
+# Release Notes — vX.Y.Z
+
+**Date:** YYYY-MM-DD
+**Branch:** `feature-branch` → `main`
+**Scope:** Sugartown monorepo (surfaces touched)
+
+---
+
+## What this release is
+
+[1–3 sentence framing of the release's overall scope and significance.]
+
+---
+
+## What changed
+
+### [Heading per meaningful theme]
+
+[Prose or bullets explaining user-facing impact. 1–4 paragraphs per section.]
+
+---
+
+## Not in this release
+
+- [Deferred work that is related enough to be worth calling out explicitly.]
+- [Placeholder routes / partial implementations.]
+- [Surfaces with no changes.]
+
+---
+
+## Validator state at release
+
+[Output of any relevant validation scripts, e.g. `pnpm validate:urls`, `pnpm validate:filters`.]
+```
+
+**Content rules:**
+- 3–8 thematic sections OR equivalent prose.
+- User-facing explanation — write for a developer who didn't write the code.
+- May omit internal-only changes (pure refactors with no surface effect).
+- May group related CHANGELOG entries into a single narrative section.
+- Must not add anything not present in CHANGELOG.
+- Must not expand beyond factual scope.
+- Must not describe future plans (the "Not in this release" section lists deferrals — it does not promise them).
+- Bug fixes may be narrated with symptoms and resolution, not just listed.
+- The "Not in this release" section is required when there are partial implementations, placeholder routes, or deferred work that could cause confusion.
+- The "Validator state at release" section is required when validation scripts exist and were run.
+
+**Tone:**
+- Clear.
+- Contextual.
+- Impact-oriented.
+- Not promotional.
+
+**Allowed transformation examples:**
+
+| CHANGELOG | Release Notes |
+|---|---|
+| `Migrated string authors to person references` | `Author attribution is now standardized using reusable Person profiles.` |
+| `Async slug-uniqueness validators removed from all schemas` | `Studio reference pills no longer ghost — async validators were blocking pill preview resolution across all content types.` |
+
+**Forbidden transformation examples:**
+
+| CHANGELOG | Forbidden Release Notes |
+|---|---|
+| `Renamed post schema to article` | `Introduced a powerful new publishing model for structured content.` ← adds interpretation |
+| `buildFilterModel() derives facet options at query time` | `A dynamic real-time filter system is now available.` ← overstates scope |
+
+---
+
+### STEP 3C — Output Artifacts
+
+AI must output:
+
+1. **CHANGELOG entry** (Markdown) — ready to prepend to `CHANGELOG.md`
+2. **RELEASE_NOTES.md** (Markdown) — full file content
+3. **Commit messages** — use conventional commits; suggest separate commits:
+   - `docs: add CHANGELOG entry for vX.Y.Z`
+   - `docs: add RELEASE_NOTES for vX.Y.Z`
+
+> **Note — RELEASE_STATE.json (retired):**
+> This artifact was carried over from the WP/Python pipeline era (`repos/sugartown-cms/.RELEASE_STATE.json`), where it functioned as a manually maintained accountability ledger — proof that the release had been consciously reviewed. It was never consumed programmatically by any script, CMS, or frontend. Its role in that era (tracking `gems_published`, `followup_items`, `verification` checklists) has no direct equivalent in the monorepo. The monorepo's equivalent accountability artifacts are `pnpm validate:urls` and `pnpm validate:filters` output, which are captured in the Release Notes "Validator state" section. Do not generate `RELEASE_STATE.json` unless automated release tooling is introduced that reads it.
+
+---
+
+## Enforcement Rules (Hard Fail Conditions)
+
+Fail if:
+- Release Notes include a change not present in CHANGELOG.
+- CHANGELOG omits a normalized change from Step 2.
+- Marketing language appears in CHANGELOG.
+- Roadmap/future language appears anywhere (except "Not in this release" — which describes deferrals, not promises).
+- Breaking changes exist but are not explicitly labeled.
+- Empty surfaces are included in CHANGELOG (e.g. `### apps/storybook` with no bullets).
+- Version format in CHANGELOG does not match the project's established versioning convention.
+
+If failure, output:
+
+```
+FAILURE REPORT
+Rule violated: [exact rule]
+Missing evidence: [what should be there]
+Return to step: [0 / 1 / 2 / 3A / 3B]
+```
+
+---
+
+## Conceptual Model (Do Not Violate)
+
+| | |
+|---|---|
+| **Changelog** | Database transaction log |
+| **Release Notes** | Dashboard summary |
+| **Changelog answers** | What changed? |
+| **Release Notes answer** | Why should anyone care? |
+
+The ledger is infrastructure.
+The narrative is communication.
+Ledger always precedes narrative.
+
+---
+
+## Version Conventions (Sugartown)
+
+- Format: SemVer `MAJOR.MINOR.PATCH` in Keep a Changelog brackets: `## [X.Y.Z] — YYYY-MM-DD`
+- Do NOT use date-only versions in the CHANGELOG header.
+- The Release Notes file header and branch metadata use `vX.Y.Z` (with `v` prefix).
+- Increment guidance:
+  - `PATCH`: bug fixes, internal refactors with no schema or API surface change
+  - `MINOR`: new features, new schema fields, new page components, new validators
+  - `MAJOR`: breaking schema changes, URL namespace changes, removed public APIs
+- When uncertain, ask the human before generating.


### PR DESCRIPTION
## Summary

- **Stages 0–7** of the monorepo parity build, merging `integration/parity-check` → `main`
- First substantive merge to `main` since the monorepo baseline (`v0.0.0`, Jan 31)
- 26 commits across `apps/web`, `apps/studio`, and `docs/`

### What's in this PR

- **Stage 0** — URL authority: `routes.js` canonical registry, `getCanonicalPath()`, `validateNavItem()`, `pnpm validate:urls`
- **Stage 1** — SEO end-to-end: `seoMetadata` schema, `SeoHead` component, site-default merge chain
- **Stage 2** — Color tokens: `colorHex` on `category` and `project`; `TaxonomyChips` with CSS custom property accent
- **Stage 3** — Archives as Sanity documents: `archivePage` schema, `ArchivePage` component, `pnpm validate:filters`
- **Stage 4** — Taxonomy architecture: `filterModel.js`, `buildFilterModel()`, GROQ fragments, `facetsRawQuery`
- **Stage 5** — Person/author entity: `person` schema, `authors[]` refs, `person.js` helpers
- **Stage 6** — `post` → `article` rename throughout: schema, queries, routes, Studio UI, production data
- **Stage 7** — Taxonomy everywhere: `authors[]`, `projects[]`, `categories[]`, `tags[]` on all content types
- **Studio bug fixes** — async slug validators removed, `person` preview simplified, `authors[]` draft filter removed
- **Sanity upgrades** — 5.9.0 → 5.11.0
- **Docs** — CHANGELOG, RELEASE_NOTES, release assistant prompt v2, morning housekeeping prompt, gem draft

### Not in this PR

- Filter bar UI (data model complete; UI deferred)
- Taxonomy detail pages (placeholder routes exist; content deferred)
- `apps/storybook` and `packages/design-system` (no changes)

### Validator state at merge

```
pnpm validate:urls    ✅ All checks passed
pnpm validate:filters ✅ All filter models produced successfully
```

## Test plan

- [ ] `pnpm validate:urls` passes
- [ ] `pnpm validate:filters` passes
- [ ] `/articles`, `/case-studies`, `/knowledge-graph` render from Sanity `archivePage` docs
- [ ] Article, case study, node detail pages render with `TaxonomyChips`
- [ ] Studio: `person` reference pills render (no ghost pills)
- [ ] Studio: `article` appears in desk structure (not `post`)
- [ ] Legacy redirects: `/blog`, `/posts`, `/post/:slug` → `/articles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #8