### PR TITLE
feat(platform): SUG-110 + SUG-111 — linear roadmap fix, DS tiles, governance reorder

### DIFF
--- a/apps/web/scripts/stats/linear.js
+++ b/apps/web/scripts/stats/linear.js
@@ -22,21 +22,26 @@ const LINEAR_API = 'https://api.linear.app/graphql'
 
 const PRIORITY_LABEL = { 0: 'No priority', 1: 'Urgent', 2: 'High', 3: 'Medium', 4: 'Low' }
 
+// Linear's `team()` query only accepts a UUID id, not a key string.
+// Use `teams` and match by key in JS instead.
 const QUERY = `
   query SugIssues {
-    team(key: "SUG") {
-      issues(
-        filter: { state: { type: { in: [started, backlog, unstarted, completed] } } }
-        first: 250
-      ) {
-        nodes {
-          identifier
-          title
-          url
-          priority
-          completedAt
-          state { name type }
-          labels { nodes { name } }
+    teams {
+      nodes {
+        key
+        issues(
+          filter: { state: { type: { in: [started, backlog, unstarted, completed] } } }
+          first: 250
+        ) {
+          nodes {
+            identifier
+            title
+            url
+            priority
+            completedAt
+            state { name type }
+            labels { nodes { name } }
+          }
         }
       }
     }
@@ -76,7 +81,9 @@ export async function collectLinear() {
   const json = await res.json()
   if (json.errors?.length) throw new Error(`Linear API errors: ${JSON.stringify(json.errors)}`)
 
-  const nodes = json.data?.team?.issues?.nodes ?? []
+  const team = (json.data?.teams?.nodes ?? []).find(t => t.key === 'SUG')
+  if (!team) throw new Error('Linear API: team with key "SUG" not found')
+  const nodes = team.issues?.nodes ?? []
 
   const inProgress = []
   const backlog    = []

--- a/apps/web/src/generated/stats.json
+++ b/apps/web/src/generated/stats.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-13T09:48:40.483Z",
+  "generatedAt": "2026-05-13T09:52:02.654Z",
   "release": {
     "current": {
       "version": "0.23.19",
@@ -77,29 +77,29 @@
     "components": 49
   },
   "repo": {
-    "commits": 1,
+    "commits": 1130,
     "epicsShipped": 96
   },
   "perf": {
-    "generatedAt": "2026-05-13T09:48:22.191Z",
+    "generatedAt": "2026-05-13T08:47:19.535Z",
     "runs": {
       "https://sugartown.io/": {
         "url": "https://sugartown.io/",
         "desktop": {
           "url": "https://sugartown.io/",
-          "lcp": 1373,
-          "cls": 0.106,
+          "lcp": 1400,
+          "cls": 0.228,
           "inp": null,
-          "performance": 93,
+          "performance": 84,
           "accessibility": 96,
           "bestPractices": 100,
           "seo": 100,
           "rating": "good"
         },
-        "lcp": 1373,
-        "cls": 0.106,
+        "lcp": 1400,
+        "cls": 0.228,
         "inp": null,
-        "performance": 93,
+        "performance": 84,
         "accessibility": 96,
         "bestPractices": 100,
         "seo": 100,
@@ -109,19 +109,19 @@
         "url": "https://sugartown.io/articles",
         "desktop": {
           "url": "https://sugartown.io/articles",
-          "lcp": 1205,
-          "cls": 0.414,
+          "lcp": 966,
+          "cls": 0.394,
           "inp": null,
-          "performance": 78,
+          "performance": 80,
           "accessibility": 95,
           "bestPractices": 100,
           "seo": 100,
           "rating": "good"
         },
-        "lcp": 1205,
-        "cls": 0.414,
+        "lcp": 966,
+        "cls": 0.394,
         "inp": null,
-        "performance": 78,
+        "performance": 80,
         "accessibility": 95,
         "bestPractices": 100,
         "seo": 100,
@@ -131,7 +131,7 @@
         "url": "https://sugartown.io/case-studies",
         "desktop": {
           "url": "https://sugartown.io/case-studies",
-          "lcp": 1210,
+          "lcp": 1205,
           "cls": 0.301,
           "inp": null,
           "performance": 82,
@@ -140,7 +140,7 @@
           "seo": 100,
           "rating": "good"
         },
-        "lcp": 1210,
+        "lcp": 1205,
         "cls": 0.301,
         "inp": null,
         "performance": 82,
@@ -153,19 +153,19 @@
         "url": "https://sugartown.io/knowledge-graph",
         "desktop": {
           "url": "https://sugartown.io/knowledge-graph",
-          "lcp": 1006,
+          "lcp": 899,
           "cls": 0.093,
           "inp": null,
-          "performance": 95,
+          "performance": 96,
           "accessibility": 95,
           "bestPractices": 100,
           "seo": 100,
           "rating": "good"
         },
-        "lcp": 1006,
+        "lcp": 899,
         "cls": 0.093,
         "inp": null,
-        "performance": 95,
+        "performance": 96,
         "accessibility": 95,
         "bestPractices": 100,
         "seo": 100,
@@ -175,19 +175,19 @@
         "url": "https://sugartown.io/platform",
         "desktop": {
           "url": "https://sugartown.io/platform",
-          "lcp": 1477,
-          "cls": 0.456,
+          "lcp": 1491,
+          "cls": 0.106,
           "inp": null,
-          "performance": 75,
+          "performance": 92,
           "accessibility": 96,
           "bestPractices": 100,
           "seo": 100,
           "rating": "good"
         },
-        "lcp": 1477,
-        "cls": 0.456,
+        "lcp": 1491,
+        "cls": 0.106,
         "inp": null,
-        "performance": 75,
+        "performance": 92,
         "accessibility": 96,
         "bestPractices": 100,
         "seo": 100,
@@ -197,19 +197,19 @@
         "url": "https://sugartown.io/about",
         "desktop": {
           "url": "https://sugartown.io/about",
-          "lcp": 1387,
-          "cls": 0.106,
+          "lcp": 1383,
+          "cls": 0.227,
           "inp": null,
-          "performance": 93,
+          "performance": 85,
           "accessibility": 94,
           "bestPractices": 100,
           "seo": 100,
           "rating": "good"
         },
-        "lcp": 1387,
-        "cls": 0.106,
+        "lcp": 1383,
+        "cls": 0.227,
         "inp": null,
-        "performance": 93,
+        "performance": 85,
         "accessibility": 94,
         "bestPractices": 100,
         "seo": 100,
@@ -219,19 +219,19 @@
         "url": "https://sugartown.io/articles/test-preview-post",
         "desktop": {
           "url": "https://sugartown.io/articles/test-preview-post",
-          "lcp": 1178,
-          "cls": 0.142,
+          "lcp": 1267,
+          "cls": 0.08,
           "inp": null,
-          "performance": 92,
+          "performance": 95,
           "accessibility": 94,
           "bestPractices": 100,
           "seo": 100,
           "rating": "good"
         },
-        "lcp": 1178,
-        "cls": 0.142,
+        "lcp": 1267,
+        "cls": 0.08,
         "inp": null,
-        "performance": 92,
+        "performance": 95,
         "accessibility": 94,
         "bestPractices": 100,
         "seo": 100,
@@ -241,34 +241,35 @@
         "url": "https://sugartown.io/nodes/test-node",
         "desktop": {
           "url": "https://sugartown.io/nodes/test-node",
-          "lcp": 975,
-          "cls": 0.142,
+          "lcp": 1300,
+          "cls": 0.08,
           "inp": null,
-          "performance": 93,
+          "performance": 95,
           "accessibility": 94,
           "bestPractices": 100,
           "seo": 100,
           "rating": "good"
         },
-        "lcp": 975,
-        "cls": 0.142,
+        "lcp": 1300,
+        "cls": 0.08,
         "inp": null,
-        "performance": 93,
+        "performance": 95,
         "accessibility": 94,
         "bestPractices": 100,
         "seo": 100,
         "rating": "good"
       }
-    }
+    },
+    "stale": true
   },
   "crux": {
-    "fetchedAt": "2026-05-13T09:48:22.369Z",
+    "fetchedAt": "2026-05-13T09:51:53.506Z",
     "origin": "https://sugartown.io",
     "available": false,
-    "reason": "no-data"
+    "reason": "no-api-key"
   },
   "security": {
-    "fetchedAt": "2026-05-13T09:48:38.452Z",
+    "fetchedAt": "2026-05-13T09:52:01.075Z",
     "vulnerabilities": {
       "total": 0,
       "critical": 0,
@@ -279,17 +280,17 @@
     }
   },
   "github": {
-    "fetchedAt": "2026-05-13T09:48:39.298Z",
+    "fetchedAt": "2026-05-13T09:52:01.795Z",
     "repo": "bex-sugartown/sugartown",
     "stars": 0,
     "watchers": 0,
     "forks": 0,
     "openIssues": 11,
     "contributors": 3,
-    "lastCommit": "2026-05-13T09:31:33Z"
+    "lastCommit": "2026-05-13T09:48:40Z"
   },
   "sanity": {
-    "fetchedAt": "2026-05-13T09:48:40.014Z",
+    "fetchedAt": "2026-05-13T09:52:02.383Z",
     "counts": {
       "article": 11,
       "node": 48,
@@ -303,7 +304,7 @@
     }
   },
   "siteGraph": {
-    "generatedAt": "2026-05-13T09:48:40.264Z",
+    "generatedAt": "2026-05-13T09:52:02.652Z",
     "nodes": [
       {
         "id": "project:sugartown-cms",
@@ -5672,6 +5673,8 @@
   },
   "linearRoadmap": {
     "stale": true,
-    "error": "Linear API → 400 Bad Request"
+    "inProgress": [],
+    "backlog": [],
+    "shipped": []
   }
 }

--- a/apps/web/src/pages/platform/DesignSystemPage.jsx
+++ b/apps/web/src/pages/platform/DesignSystemPage.jsx
@@ -6,7 +6,10 @@ import SectionLabel from '../../design-system/components/section-label/SectionLa
 import Card from '../../design-system/components/card/Card'
 import { MermaidDiagram } from '../../components/PageSections'
 import { PLATFORM_ROUTES, TRUST_LINKS, FIGJAM_URLS } from '../../lib/routes'
+import stats from '../../generated/stats.json'
 import styles from './PlatformHubPage.module.css'
+
+const ds = stats.ds ?? {}
 
 const REGISTRY_PREVIEW = [
   { name: 'Card', desc: 'Content surface — folio, metadata, listing, and KPI variants.' },
@@ -70,10 +73,10 @@ export default function DesignSystemPage() {
       <div className={styles.hub}>
 
         <SectionContainer className={styles.statsSection}>
-          <Tile label="Components" value="42" href={PLATFORM_ROUTES.dsRegistry} />
-          <Tile label="Tokens" value="590" />
-          <Tile label="Themes" value="2" />
-          <Tile label="Storybook" value="pinkmoon ↗" href={TRUST_LINKS.storybook} />
+          <Tile label="Design tokens"     value={ds.tokens?.total ?? '—'} href={TRUST_LINKS.storybook} />
+          <Tile label="DS components"     value={ds.dsComponents ?? '—'} href={PLATFORM_ROUTES.dsRegistry} />
+          <Tile label="Story coverage"    value={ds.dsComponents ? `${Math.round((ds.dsComponentsWithStories / ds.dsComponents) * 100)}%` : '—'} href={TRUST_LINKS.storybook} />
+          <Tile label="Token compliance"  value={ds.tokenCompliance != null ? `${ds.tokenCompliance}%` : '—'} />
         </SectionContainer>
 
         <section id="token-architecture" className={styles.section}>

--- a/apps/web/src/pages/platform/DesignSystemPage.jsx
+++ b/apps/web/src/pages/platform/DesignSystemPage.jsx
@@ -73,10 +73,36 @@ export default function DesignSystemPage() {
       <div className={styles.hub}>
 
         <SectionContainer className={styles.statsSection}>
-          <Tile label="Design tokens"     value={ds.tokens?.total ?? '—'} href={TRUST_LINKS.storybook} />
-          <Tile label="DS components"     value={ds.dsComponents ?? '—'} href={PLATFORM_ROUTES.dsRegistry} />
-          <Tile label="Story coverage"    value={ds.dsComponents ? `${Math.round((ds.dsComponentsWithStories / ds.dsComponents) * 100)}%` : '—'} href={TRUST_LINKS.storybook} />
-          <Tile label="Token compliance"  value={ds.tokenCompliance != null ? `${ds.tokenCompliance}%` : '—'} />
+          <Tile
+            label="Design tokens"
+            value={ds.tokens?.total ?? '—'}
+            legend
+            bar={ds.tokens?.primitives != null ? {
+              segments: [
+                { label: 'Primitive',  value: ds.tokens.primitives, color: 'var(--st-color-accent)' },
+                { label: 'Semantic',   value: ds.tokens.semantic,   color: 'var(--st-color-seafoam)' },
+                { label: 'Component',  value: ds.tokens.component,  color: 'var(--st-color-violet)' },
+              ],
+            } : undefined}
+            href={TRUST_LINKS.storybook}
+          />
+          <Tile
+            label="DS components"
+            value={ds.dsComponents ?? '—'}
+            sub={ds.webAdapters != null ? `+ ${ds.webAdapters} web adapters` : undefined}
+            href={PLATFORM_ROUTES.dsRegistry}
+          />
+          <Tile
+            label="Story coverage"
+            value={ds.dsComponents ? `${Math.round((ds.dsComponentsWithStories / ds.dsComponents) * 100)}%` : '—'}
+            sub={ds.dsComponentsWithStories != null && ds.dsComponents != null ? `${ds.dsComponentsWithStories} of ${ds.dsComponents} DS components` : undefined}
+            href={TRUST_LINKS.storybook}
+          />
+          <Tile
+            label="Token compliance"
+            value={ds.tokenCompliance != null ? `${ds.tokenCompliance}%` : '—'}
+            sub="CSS var refs using --st-* tokens"
+          />
         </SectionContainer>
 
         <section id="token-architecture" className={styles.section}>

--- a/apps/web/src/pages/platform/GovernancePage.jsx
+++ b/apps/web/src/pages/platform/GovernancePage.jsx
@@ -116,8 +116,7 @@ export default function GovernancePage() {
 
           {isStale && (
             <Callout>
-              Live roadmap data unavailable — <code>LINEAR_API_KEY</code> not configured in CI.
-              Full backlog on{' '}
+              Roadmap data pending next CI run. Full backlog on{' '}
               <a href="https://linear.app/sugartown" target="_blank" rel="noreferrer">Linear ↗</a>.
             </Callout>
           )}

--- a/apps/web/src/pages/platform/GovernancePage.jsx
+++ b/apps/web/src/pages/platform/GovernancePage.jsx
@@ -138,11 +138,6 @@ export default function GovernancePage() {
           )}
         </section>
 
-        <section id="release-process" className={styles.section}>
-          <SectionLabel name="Release process" kicker="Gate model" />
-          <MermaidDiagram section={RELEASE_DIAGRAM} />
-        </section>
-
         <section id="recent-releases" className={styles.section}>
           <SectionLabel name="Recent releases" kicker="Last 5" />
           <DataTable columns={RELEASE_COLUMNS} rows={RECENT_RELEASES} variant="trust" />
@@ -150,6 +145,11 @@ export default function GovernancePage() {
             <a href={TRUST_LINKS.changelog} className={styles.trustLink} target="_blank" rel="noreferrer">Full changelog</a>
             <a href={TRUST_LINKS.commits}   className={styles.trustLink} target="_blank" rel="noreferrer">Commit log</a>
           </div>
+        </section>
+
+        <section id="release-process" className={styles.section}>
+          <SectionLabel name="Release process" kicker="Gate model" />
+          <MermaidDiagram section={RELEASE_DIAGRAM} />
         </section>
 
         <section id="governance-artifacts" className={styles.section}>


### PR DESCRIPTION
## Summary

- Fixes Linear collector query: `team(key:)` is invalid GraphQL — switched to `teams { nodes }` filtered by key in JS, resolving the 400 Bad Request that blocked roadmap data
- DesignSystemPage stat tiles now live from `stats.ds` — design tokens tile gets segmented bar + legend (Primitive/Semantic/Component), other tiles get sub-copy
- Governance page: Recent Releases section moved above Release Process
- Stale callout copy updated to "Roadmap data pending next CI run."

## Test plan

- [ ] After merge, trigger `gh workflow run stats.yml` — confirm `linearRoadmap.fetchedAt` populates in stats.json
- [ ] `/platform/design-system` — tiles show 590 / 13 / 85% / 98% with bar and sub-copy
- [ ] `/platform/governance` — Recent Releases renders above Release Process; roadmap tables appear once stats run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)