### PR TITLE
EXPERIMENT — do not merge: observe the SUG-281 warn-gate annotation channel

### DIFF
--- a/scripts/validate-doc-budget.js
+++ b/scripts/validate-doc-budget.js
@@ -70,7 +70,7 @@ const ROOT_DOC = 'CLAUDE.md'
  * gate red on landing and `gateProbe` reports PROBE INVALID rather than proving
  * anything.
  */
-const CAP_WORDS = 26_000
+const CAP_WORDS = 1_000 // EXPERIMENT ONLY — SUG-281 warn-gate semantics. Never merge.
 
 /**
  * Decision-point cap — added 2026-08-05.


### PR DESCRIPTION
**Do not merge. Do not squash. This branch exists to be deleted.**

## Why this exists

SUG-281 Phase 1 shipped a warn-gate annotation channel: a `continue-on-error` step carries an `id`, and a follow-on step gated on `steps.<id>.outcome == 'failure'` emits `::warning title=WARN-GATE::`. `/eod` reads those annotations, because `ci-failure-alert.yml` cannot — it fires only on `conclusion == 'failure'`, which `continue-on-error` makes unreachable.

Three mechanics that design rests on are documented by GitHub but had **never been executed in this repo**. A search of 40 CI runs and 40 `stats.yml` runs found no `success` job containing a `failure` step, so there was no evidence either way. `CTL-041`'s Bypass cell records them as unverified rather than implying the channel is proven.

Without this run, the channel's first real firing would also be its first test — the exact pattern SUG-281 exists to end.

## What this branch does

Lowers `CAP_WORDS` in `scripts/validate-doc-budget.js` from 26,000 to 1,000, so the warn-only *Validate doc budget* step fails deterministically. No instruction content is touched.

Committed with `--no-verify` deliberately: `validate:doc-budget` blocks at pre-commit by design (CTL-025). That is the gate working. This is the one commit where the breakage is the point.

## What to read off the run

1. Does `if: steps.doc_budget.outcome == 'failure'` fire the *Warn-gate annotation — doc budget* step, given the step it names was swallowed by `continue-on-error`?
2. Does GitHub emit its own failure-level annotation for a swallowed step, and does it name the step?
3. Does REST `steps[].conclusion` stay `failure` inside a job that concluded `success`?

Expected: the run concludes **success** despite a red gate. If it concludes `failure`, the `continue-on-error` wiring is not doing what SUG-281 assumed and Phase 1 needs revisiting.

The `validate:epic-docs` step is wired identically and is not separately broken here — its annotation pairing is enforced by `validate:validators (warn-gate pairing)`, which is probed.

## After

Findings go into `CTL-041`'s Bypass cell and the SUG-281 epic doc, with this run ID as the artifact. Then this branch is deleted.